### PR TITLE
Add sitemap and robots routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Tous les composants UI sont basés sur ShadCN et se trouvent dans \`components/u
 1. Connectez votre repo GitHub à Vercel
 2. Configurez les variables d'environnement
 3. Déployez automatiquement
+4. Vérifiez que `NEXT_PUBLIC_SITE_URL` pointe vers votre domaine afin que les routes `/sitemap.xml` et `/robots.txt` soient correctement générées. Une fois le déploiement terminé, elles doivent être accessibles.
 
 ### Autres plateformes
 Le projet est compatible avec toute plateforme supportant Next.js (Netlify, Railway, etc.)

--- a/app/robots.txt/route.ts
+++ b/app/robots.txt/route.ts
@@ -1,0 +1,9 @@
+export async function GET() {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+  const content = `User-agent: *\nAllow: /\nSitemap: ${baseUrl}/sitemap.xml`;
+  return new Response(content, {
+    headers: {
+      "Content-Type": "text/plain",
+    },
+  });
+}

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -1,0 +1,48 @@
+import { prisma } from "@/lib/prisma";
+
+export async function GET() {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+
+  const [projects, articles] = await Promise.all([
+    prisma.project.findMany({
+      where: { isPublished: true },
+      select: { slug: true, updatedAt: true },
+    }),
+    prisma.article.findMany({
+      where: { isPublished: true },
+      select: { slug: true, updatedAt: true },
+    }),
+  ]);
+
+  const staticPaths = [
+    "",
+    "/projects",
+    "/services",
+    "/articles",
+    "/parcours",
+    "/contact",
+  ];
+
+  const urls = [
+    ...staticPaths.map(
+      (path) => `<url><loc>${baseUrl}${path}</loc></url>`
+    ),
+    ...projects.map(
+      (p) =>
+        `<url><loc>${baseUrl}/projects/${p.slug}</loc><lastmod>${p.updatedAt.toISOString()}</lastmod></url>`
+    ),
+    ...articles.map(
+      (a) =>
+        `<url><loc>${baseUrl}/articles/${a.slug}</loc><lastmod>${a.updatedAt.toISOString()}</lastmod></url>`
+    ),
+  ].join("");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls}</urlset>`;
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/xml",
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- generate sitemap.xml from published articles and projects
- add robots.txt pointing to sitemap
- document deployment check for SEO routes

## Testing
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e5ff3f528832784d4a22d9551feee