### PR TITLE
Add canonical URLs

### DIFF
--- a/app/(main)/articles/[slug]/page.tsx
+++ b/app/(main)/articles/[slug]/page.tsx
@@ -31,6 +31,12 @@ export async function generateMetadata({
   return {
     title: `${article.title} | Blog`,
     description: article.excerpt,
+    alternates: {
+      canonical: new URL(
+        `/articles/${slug}`,
+        process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+      ).toString(),
+    },
     openGraph: {
       title: article.title,
       description: article.excerpt,

--- a/app/(main)/contact/page.tsx
+++ b/app/(main)/contact/page.tsx
@@ -14,6 +14,12 @@ import { prisma } from "@/lib/prisma";
 export const metadata: Metadata = {
   title: "Contact | Matheus Kops Guedes",
   description: "Contactez-moi pour discuter de vos projets et collaborations",
+  alternates: {
+    canonical: new URL(
+      "/contact",
+      process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+    ).toString(),
+  },
 };
 
 async function getContactSettings() {

--- a/app/(main)/parcours/layout.tsx
+++ b/app/(main)/parcours/layout.tsx
@@ -3,6 +3,12 @@ import { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Parcours | Matheus Kops Guedes",
   description: "Découvrez mon parcours académique et professionnel, formations et expériences.",
+  alternates: {
+    canonical: new URL(
+      "/parcours",
+      process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+    ).toString(),
+  },
 };
 
 export default function ParcoursLayout({

--- a/app/(main)/services/page.tsx
+++ b/app/(main)/services/page.tsx
@@ -24,6 +24,12 @@ export const metadata: Metadata = {
   title: "Services | Matheus Kops Guedes",
   description:
     "Découvrez mes services de développement web, création d'API, optimisation et consulting technique.",
+  alternates: {
+    canonical: new URL(
+      "/services",
+      process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+    ).toString(),
+  },
 };
 
 async function getServices() {

--- a/app/admin/articles/[id]/edit/page.tsx
+++ b/app/admin/articles/[id]/edit/page.tsx
@@ -8,10 +8,20 @@ import { Button } from "@/components/ui/button";
 import { ArrowLeft } from "lucide-react";
 import { EditArticleForm } from "@/components/admin/EditArticleForm";
 
-export const metadata: Metadata = {
-  title: "Éditer Article | Admin",
-  description: "Édition d'un article (admin)",
-};
+export async function generateMetadata({
+  params,
+}: { params: { id: string } }): Promise<Metadata> {
+  return {
+    title: "Éditer Article | Admin",
+    description: "Édition d'un article (admin)",
+    alternates: {
+      canonical: new URL(
+        `/admin/articles/${params.id}/edit`,
+        process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+      ).toString(),
+    },
+  };
+}
 
 export default async function AdminArticleEditPage({
   params,

--- a/app/admin/articles/new/page.tsx
+++ b/app/admin/articles/new/page.tsx
@@ -10,6 +10,12 @@ import { NewArticleForm } from "@/components/admin/NewArticleForm";
 export const metadata: Metadata = {
   title: "Nouvel Article | Admin",
   description: "Rédiger un nouvel article de blog",
+  alternates: {
+    canonical: new URL(
+      "/admin/articles/new",
+      process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+    ).toString(),
+  },
 };
 
 export default async function NewArticlePage() {

--- a/app/admin/articles/page.tsx
+++ b/app/admin/articles/page.tsx
@@ -10,6 +10,12 @@ import { Button } from "@/components/ui/button";
 export const metadata: Metadata = {
   title: "Articles | Admin",
   description: "Gestion des articles du blog (admin)",
+  alternates: {
+    canonical: new URL(
+      "/admin/articles",
+      process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+    ).toString(),
+  },
 };
 
 export default async function AdminArticlesPage() {

--- a/app/admin/images/page.tsx
+++ b/app/admin/images/page.tsx
@@ -4,6 +4,12 @@ import { ImageCleanupManager } from '@/components/admin/ImageCleanupManager';
 export const metadata: Metadata = {
   title: `Gestion des images | Admin`,
   description: `Nettoyage et gestion des images orphelines`,
+  alternates: {
+    canonical: new URL(
+      "/admin/images",
+      process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+    ).toString(),
+  },
 };
 
 export default async function AdminImagesPage() {

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -12,7 +12,13 @@ import { RecentItems } from "@/components/admin/RecentItems"
 export const metadata: Metadata = {
   title: "Dashboard Admin | Portfolio",
   description: "Interface d'administration du portfolio",
-}
+  alternates: {
+    canonical: new URL(
+      "/admin",
+      process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+    ).toString(),
+  },
+};
 
 async function getAdminData() {
   try {

--- a/app/admin/parcours/educations/[id]/edit/page.tsx
+++ b/app/admin/parcours/educations/[id]/edit/page.tsx
@@ -5,10 +5,20 @@ import { headers } from "next/headers";
 import { prisma } from "@/lib/prisma";
 import { EducationForm } from "@/components/admin/EducationForm";
 
-export const metadata: Metadata = {
-  title: "Modifier Formation | Admin",
-  description: "Modifier une formation",
-};
+export async function generateMetadata({
+  params,
+}: { params: { id: string } }): Promise<Metadata> {
+  return {
+    title: "Modifier Formation | Admin",
+    description: "Modifier une formation",
+    alternates: {
+      canonical: new URL(
+        `/admin/parcours/educations/${params.id}/edit`,
+        process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+      ).toString(),
+    },
+  };
+}
 
 interface PageProps {
   params: Promise<{

--- a/app/admin/parcours/educations/new/page.tsx
+++ b/app/admin/parcours/educations/new/page.tsx
@@ -7,6 +7,12 @@ import { EducationForm } from "@/components/admin/EducationForm";
 export const metadata: Metadata = {
   title: "Nouvelle Formation | Admin",
   description: "Ajouter une nouvelle formation",
+  alternates: {
+    canonical: new URL(
+      "/admin/parcours/educations/new",
+      process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+    ).toString(),
+  },
 };
 
 export default async function NewEducationPage() {

--- a/app/admin/parcours/experiences/[id]/edit/page.tsx
+++ b/app/admin/parcours/experiences/[id]/edit/page.tsx
@@ -5,10 +5,20 @@ import { headers } from "next/headers";
 import { prisma } from "@/lib/prisma";
 import { ExperienceForm } from "@/components/admin/ExperienceForm";
 
-export const metadata: Metadata = {
-  title: "Modifier Expérience | Admin",
-  description: "Modifier une expérience",
-};
+export async function generateMetadata({
+  params,
+}: { params: { id: string } }): Promise<Metadata> {
+  return {
+    title: "Modifier Expérience | Admin",
+    description: "Modifier une expérience",
+    alternates: {
+      canonical: new URL(
+        `/admin/parcours/experiences/${params.id}/edit`,
+        process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+      ).toString(),
+    },
+  };
+}
 
 interface PageProps {
   params: Promise<{

--- a/app/admin/parcours/experiences/new/page.tsx
+++ b/app/admin/parcours/experiences/new/page.tsx
@@ -7,6 +7,12 @@ import { ExperienceForm } from "@/components/admin/ExperienceForm";
 export const metadata: Metadata = {
   title: "Nouvelle Expérience | Admin",
   description: "Ajouter une nouvelle expérience",
+  alternates: {
+    canonical: new URL(
+      "/admin/parcours/experiences/new",
+      process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+    ).toString(),
+  },
 };
 
 export default async function NewExperiencePage() {

--- a/app/admin/parcours/page.tsx
+++ b/app/admin/parcours/page.tsx
@@ -8,6 +8,12 @@ import { ParcoursManager } from "@/components/admin/ParcoursManager";
 export const metadata: Metadata = {
   title: "Parcours | Admin",
   description: "Gestion des formations et expériences",
+  alternates: {
+    canonical: new URL(
+      "/admin/parcours",
+      process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+    ).toString(),
+  },
 };
 
 async function getEducations() {

--- a/app/admin/projects/[id]/edit/page.tsx
+++ b/app/admin/projects/[id]/edit/page.tsx
@@ -8,10 +8,20 @@ import { Button } from "@/components/ui/button";
 import { ArrowLeft } from "lucide-react";
 import { EditProjectForm } from "@/components/admin/EditProjectForm";
 
-export const metadata: Metadata = {
-  title: "Éditer Projet | Admin",
-  description: "Édition d'un projet (admin)",
-};
+export async function generateMetadata({
+  params,
+}: { params: { id: string } }): Promise<Metadata> {
+  return {
+    title: "Éditer Projet | Admin",
+    description: "Édition d'un projet (admin)",
+    alternates: {
+      canonical: new URL(
+        `/admin/projects/${params.id}/edit`,
+        process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+      ).toString(),
+    },
+  };
+}
 
 export default async function AdminProjectEditPage({
   params,

--- a/app/admin/projects/[id]/page.tsx
+++ b/app/admin/projects/[id]/page.tsx
@@ -13,10 +13,20 @@ import { ImageReady } from "@/components/ui/ImageReady";
 import { DeleteProjectButton } from "@/components/admin/DeleteProjectButton";
 import { Project } from "@prisma/client";
 
-export const metadata: Metadata = {
-  title: "Détail Projet | Admin",
-  description: "Détail d'un projet (admin)",
-};
+export async function generateMetadata({
+  params,
+}: { params: { id: string } }): Promise<Metadata> {
+  return {
+    title: "Détail Projet | Admin",
+    description: "Détail d'un projet (admin)",
+    alternates: {
+      canonical: new URL(
+        `/admin/projects/${params.id}`,
+        process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+      ).toString(),
+    },
+  };
+}
 
 export default async function AdminProjectDetailPage({
   params,

--- a/app/admin/projects/new/page.tsx
+++ b/app/admin/projects/new/page.tsx
@@ -7,6 +7,12 @@ import { NewProjectForm } from "@/components/admin/NewProjectForm";
 export const metadata: Metadata = {
   title: "Nouveau Projet | Admin",
   description: "Ajouter un nouveau projet au portfolio",
+  alternates: {
+    canonical: new URL(
+      "/admin/projects/new",
+      process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+    ).toString(),
+  },
 };
 
 export default function NewProjectPage() {

--- a/app/admin/projects/page.tsx
+++ b/app/admin/projects/page.tsx
@@ -10,6 +10,12 @@ import { Button } from "@/components/ui/button";
 export const metadata: Metadata = {
   title: "Projets | Admin",
   description: "Gestion des projets du portfolio (admin)",
+  alternates: {
+    canonical: new URL(
+      "/admin/projects",
+      process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+    ).toString(),
+  },
 };
 
 export default async function AdminProjectsPage() {

--- a/app/admin/services/page.tsx
+++ b/app/admin/services/page.tsx
@@ -8,6 +8,12 @@ import { ServicesManager } from "@/components/admin/ServicesManager";
 export const metadata: Metadata = {
   title: "Services | Admin",
   description: "Gestion des services",
+  alternates: {
+    canonical: new URL(
+      "/admin/services",
+      process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+    ).toString(),
+  },
 };
 
 async function getServices() {

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -7,6 +7,12 @@ import { SettingsForm } from "@/components/admin/SettingsForm";
 export const metadata: Metadata = {
   title: "Paramètres | Admin",
   description: "Configuration des paramètres de contact et SMTP",
+  alternates: {
+    canonical: new URL(
+      "/admin/settings",
+      process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+    ).toString(),
+  },
 };
 
 export default async function SettingsPage() {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,6 +29,12 @@ export const metadata: Metadata = {
   metadataBase: new URL(
     process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
   ),
+  alternates: {
+    canonical: new URL(
+      "/",
+      process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+    ).toString(),
+  },
   openGraph: {
     type: "website",
     locale: "fr_FR",

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -4,6 +4,12 @@ import { LoginForm } from "@/components/auth/LoginForm";
 export const metadata: Metadata = {
   title: "Connexion Admin | Portfolio",
   description: "Accès à l'interface d'administration du portfolio",
+  alternates: {
+    canonical: new URL(
+      "/login",
+      process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+    ).toString(),
+  },
 };
 
 export default function LoginPage() {


### PR DESCRIPTION
## Summary
- add canonical URL alternates in site root layout
- include canonical URLs for each page's metadata
- compute canonical URLs in dynamic metadata for slug & id pages

## Testing
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e5ff513508327a1d63d7a831d75fb